### PR TITLE
docs: Fix simple typo, homogenous -> homogeneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,13 +328,13 @@ Subsample data using MinMax.
 
 MinMax will display the extrema of the subsample intervals.  This is
 slower than regular interval subsampling but necessary for data that 
-is very non-homogenous.
+is very non-homogeneous.
 
 ##### `subsample (resolution)`
 Subsample data at a regular interval for resolution.
 
 This is the fastest subsampling and good for monotonic data and fairly
-homogenous data (not a lot of up and down).
+homogeneous data (not a lot of up and down).
 
 ### Class `envision.Interaction`
 _Defines an interaction between components._

--- a/envision.js
+++ b/envision.js
@@ -6495,7 +6495,7 @@ Preprocessor.prototype = {
    *
    * MinMax will display the extrema of the subsample intervals.  This is
    * slower than regular interval subsampling but necessary for data that 
-   * is very non-homogenous.
+   * is very non-homogeneous.
    *
    * @param {Number} resolution
    */
@@ -6585,7 +6585,7 @@ Preprocessor.prototype = {
    * Subsample data at a regular interval for resolution.
    *
    * This is the fastest subsampling and good for monotonic data and fairly
-   * homogenous data (not a lot of up and down).
+   * homogeneous data (not a lot of up and down).
    *
    * @param {Number} resolution
    */

--- a/js/Preprocessor.js
+++ b/js/Preprocessor.js
@@ -135,7 +135,7 @@ Preprocessor.prototype = {
    *
    * MinMax will display the extrema of the subsample intervals.  This is
    * slower than regular interval subsampling but necessary for data that 
-   * is very non-homogenous.
+   * is very non-homogeneous.
    *
    * @param {Number} resolution
    */
@@ -225,7 +225,7 @@ Preprocessor.prototype = {
    * Subsample data at a regular interval for resolution.
    *
    * This is the fastest subsampling and good for monotonic data and fairly
-   * homogenous data (not a lot of up and down).
+   * homogeneous data (not a lot of up and down).
    *
    * @param {Number} resolution
    */

--- a/markdown/api.md
+++ b/markdown/api.md
@@ -171,13 +171,13 @@ Subsample data using MinMax.
 
 MinMax will display the extrema of the subsample intervals.  This is
 slower than regular interval subsampling but necessary for data that 
-is very non-homogenous.
+is very non-homogeneous.
 
 ##### `subsample (resolution)`
 Subsample data at a regular interval for resolution.
 
 This is the fastest subsampling and good for monotonic data and fairly
-homogenous data (not a lot of up and down).
+homogeneous data (not a lot of up and down).
 
 ### Class `envision.Interaction`
 _Defines an interaction between components._


### PR DESCRIPTION
There is a small typo in README.md, envision.js, js/Preprocessor.js, markdown/api.md.

Should read `homogeneous` rather than `homogenous`.

